### PR TITLE
Fix crash with empty or shuffled folder

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -37,7 +37,7 @@
         }
     },
     "name": "media-playlist-source",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "author": "Ian Rodriguez",
     "website": "https://github.com/CodeYan01/media-playlist-source",
     "email": "ianlemuelr@gmail.com",

--- a/src/media-playlist-source.h
+++ b/src/media-playlist-source.h
@@ -80,10 +80,10 @@ struct media_playlist_source {
 };
 
 static const char *media_filter =
-	" (*.mp4 *.m4v *.ts *.mov *.mxf *.flv *.mkv *.avi *.mp3 *.ogg *.aac *.wav *.gif *.webm);;";
+	" (*.mp4 *.mpg *.m4v *.ts *.mov *.mxf *.flv *.mkv *.avi *.gif *.webm *.mp3 *.m4a *.ogg *.aac *.wav *.opus *.flac);;";
 static const char *video_filter =
-	" (*.mp4 *.m4v *.ts *.mov *.mxf *.flv *.mkv *.avi *.gif *.webm);;";
-static const char *audio_filter = " (*.mp3 *.aac *.ogg *.wav);;";
+	" (*.mp4 *.mpg *.m4v *.ts *.mov *.mxf *.flv *.mkv *.avi *.gif *.webm);;";
+static const char *audio_filter = " (*.mp3 *.m4a *.mka *.aac *.ogg *.wav *.opus *.flac);;";
 
 static void set_current_media_index(struct media_playlist_source *mps,
 				    size_t index);


### PR DESCRIPTION
Crash 1 happens when an empty folder is added (might only be due it being the first list item).

Crash 2 happens when shuffle is enabled and a folder is added.