### PR TITLE
Fix actual settings (index and filename) in source

### DIFF
--- a/src/media-playlist-source.c
+++ b/src/media-playlist-source.c
@@ -1268,6 +1268,8 @@ static void mps_save(void *data, obs_data_t *settings)
 	struct media_playlist_source *mps = data;
 	obs_data_set_int(settings, S_CURRENT_MEDIA_INDEX, mps->current_media_index);
 	obs_data_set_string(settings, S_CURRENT_FOLDER_ITEM_FILENAME, mps->current_media_filename);
+
+	obs_source_update(mps->source, settings);
 }
 
 static void mps_load(void *data, obs_data_t *settings)


### PR DESCRIPTION
Fix the issue when trying to access plugin settings from outside, such as in a Python script, where the data is not updated

```python
media_source= obs.obs_get_source_by_name(MEDIA_SOURCE_NAME)

settings = obs.obs_source_get_settings(media_source)
current_media_index = obs.obs_data_get_int(settings, "current_media_index") <- never updating
current_file_name = obs.obs_data_get_string(settings, "current_file_name") <- never updating
```